### PR TITLE
support JVP for 3DGS rasterizer

### DIFF
--- a/bindings/cugsplat/cuda/csrc/Ops.h
+++ b/bindings/cugsplat/cuda/csrc/Ops.h
@@ -23,6 +23,25 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> image_gaussian_rasterize_forward(
     const at::Tensor isect_prefix_sum_per_tile // [n_tiles]
 );
 
+std::tuple<at::Tensor, at::Tensor, at::Tensor> image_gaussian_rasterize_jvp(
+    // Primitives
+    const at::Tensor opacities, // [n_primitives, 2]
+    const at::Tensor means2d,   // [n_primitives, 2, 2]
+    const at::Tensor conics,    // [n_primitives, 3, 2]
+    const at::Tensor features,  // [n_primitives, channels, 2]
+
+    // Images
+    const int64_t n_images,
+    const int64_t image_width,
+    const int64_t image_height,
+    const int64_t tile_width,
+    const int64_t tile_height,
+
+    // Intersections
+    const at::Tensor isect_primitive_ids,      // [n_isects]
+    const at::Tensor isect_prefix_sum_per_tile // [n_tiles]
+);
+
 std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor>
 image_gaussian_rasterize_backward(
     // Primitives

--- a/bindings/cugsplat/cuda/csrc/RasterizeToPixels3DGS.cpp
+++ b/bindings/cugsplat/cuda/csrc/RasterizeToPixels3DGS.cpp
@@ -8,6 +8,8 @@
 #include "Common.h"
 #include "Ops.h"
 #include "RasterizeToPixels3DGS.h"
+#include "tinyrend/common/scalar_grad.h"
+#include "tinyrend/common/vec.h"
 
 namespace cugsplat {
 
@@ -54,7 +56,7 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> image_gaussian_rasterize_forward(
     // Launch kernel
 #define __LAUNCH_KERNEL__(DIM)                                                         \
     case DIM:                                                                          \
-        image_gaussian_rasterize_kernel_forward<DIM>(                                  \
+        image_gaussian_rasterize_kernel_forward<DIM, float, fvec2, fvec3>(             \
             n_primitives,                                                              \
             opacities.data_ptr<float>(),                                               \
             reinterpret_cast<fvec2 *>(means2d.data_ptr<float>()),                      \
@@ -70,6 +72,84 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> image_gaussian_rasterize_forward(
             render_last_index.data_ptr<int32_t>(),                                     \
             render_alpha.data_ptr<float>(),                                            \
             reinterpret_cast<fvec<DIM> *>(render_feature.data_ptr<float>())            \
+        );                                                                             \
+        break;
+
+    switch (channels) {
+        __LAUNCH_KERNEL__(3)
+    default:
+        AT_ERROR("Unsupported number of channels: ", channels);
+    }
+#undef __LAUNCH_KERNEL__
+
+    return {render_feature, render_alpha, render_last_index};
+}
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor> image_gaussian_rasterize_jvp(
+    // Primitives
+    const at::Tensor opacities, // [n_primitives, 2]
+    const at::Tensor means2d,   // [n_primitives, 2, 2]
+    const at::Tensor conics,    // [n_primitives, 3, 2]
+    const at::Tensor features,  // [n_primitives, channels, 2]
+
+    // Images
+    const int64_t n_images,
+    const int64_t image_width,
+    const int64_t image_height,
+    const int64_t tile_width,
+    const int64_t tile_height,
+
+    // Intersections
+    const at::Tensor isect_primitive_ids,      // [n_isects]
+    const at::Tensor isect_prefix_sum_per_tile // [n_tiles]
+) {
+    DEVICE_GUARD(means2d);
+
+    // Check inputs
+    CHECK_INPUT(means2d);
+    CHECK_INPUT(conics);
+    CHECK_INPUT(features);
+    CHECK_INPUT(opacities);
+    CHECK_INPUT(isect_primitive_ids);
+    CHECK_INPUT(isect_prefix_sum_per_tile);
+
+    const int64_t n_primitives = means2d.size(0);
+    const int64_t channels = features.size(1);
+
+    // Create outputs
+    at::Tensor render_last_index = at::empty(
+        {n_images, image_height, image_width, 1}, means2d.options().dtype(at::kInt)
+    );
+    at::Tensor render_alpha =
+        at::empty({n_images, image_height, image_width, 1, 2}, means2d.options());
+    at::Tensor render_feature = at::empty(
+        {n_images, image_height, image_width, channels, 2}, means2d.options()
+    );
+
+    using ScalarType = scalar_grad<float>;
+    using Vec2Type = vec<scalar_grad<float>, 2>;
+    using Vec3Type = vec<scalar_grad<float>, 3>;
+
+    // Launch kernel
+#define __LAUNCH_KERNEL__(DIM)                                                         \
+    case DIM:                                                                          \
+        using FeatureType = vec<scalar_grad<float>, DIM>;                              \
+        image_gaussian_rasterize_kernel_forward<DIM, ScalarType, Vec2Type, Vec3Type>(  \
+            n_primitives,                                                              \
+            reinterpret_cast<ScalarType *>(opacities.data_ptr<float>()),               \
+            reinterpret_cast<Vec2Type *>(means2d.data_ptr<float>()),                   \
+            reinterpret_cast<Vec3Type *>(conics.data_ptr<float>()),                    \
+            reinterpret_cast<FeatureType *>(features.data_ptr<float>()),               \
+            n_images,                                                                  \
+            image_height,                                                              \
+            image_width,                                                               \
+            tile_width,                                                                \
+            tile_height,                                                               \
+            isect_primitive_ids.data_ptr<uint32_t>(),                                  \
+            isect_prefix_sum_per_tile.data_ptr<uint32_t>(),                            \
+            render_last_index.data_ptr<int32_t>(),                                     \
+            reinterpret_cast<ScalarType *>(render_alpha.data_ptr<float>()),            \
+            reinterpret_cast<FeatureType *>(render_feature.data_ptr<float>())          \
         );                                                                             \
         break;
 

--- a/bindings/cugsplat/cuda/csrc/RasterizeToPixels3DGS.h
+++ b/bindings/cugsplat/cuda/csrc/RasterizeToPixels3DGS.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 
 #include "tinyrend/common/macros.h"
+#include "tinyrend/common/scalar_grad.h"
 #include "tinyrend/common/vec.h"
 
 namespace cugsplat {
@@ -12,46 +13,56 @@ using namespace tinyrend;
 
 #ifdef __CUDA_ARCH__ // Shared between forward and backward cuda kernels
 
+template <typename ScalarType, typename Vec3Type>
 struct EvaluateLightAttenuationContext {
-    float alpha;
-    float vis;
-    fvec3 conic;
-    float dx;
-    float dy;
+    ScalarType alpha;
+    ScalarType vis;
+    Vec3Type conic;
+    ScalarType dx;
+    ScalarType dy;
     float maximum_alpha;
 };
 
+template <typename ScalarType, typename Vec2Type, typename Vec3Type>
 inline TREND_HOST_DEVICE auto evaluate_light_attenuation_forward(
-    const float opacity,
-    const fvec2 mean,
-    const fvec3 conic,
+    const ScalarType opacity,
+    const Vec2Type mean,
+    const Vec3Type conic,
     const float pixel_x,
     const float pixel_y,
     const float maximum_alpha
-) -> std::pair<float, EvaluateLightAttenuationContext> {
+) -> std::pair<ScalarType, EvaluateLightAttenuationContext<ScalarType, Vec3Type>> {
     // TODO(ruilong): do we really need to add 0.5f here?
     auto const dx = pixel_x + 0.5f - mean[0];
     auto const dy = pixel_y + 0.5f - mean[1];
     auto const sigma =
         0.5f * (conic[0] * dx * dx + conic[2] * dy * dy) + conic[1] * dx * dy;
-    auto const vis = __expf(-sigma); // Device code: use fast CUDA intrinsic
+    ScalarType vis;
+    if constexpr (std::is_same_v<ScalarType, float>) {
+        vis = __expf(-sigma); // Device code: use fast CUDA intrinsic
+    } else {
+        vis = exp(-sigma); // Use standard exp
+    }
     auto const alpha = opacity * vis;
-    auto const output = min(alpha, maximum_alpha);
+    auto const output = fmin(alpha, maximum_alpha);
     return {
         output,
-        EvaluateLightAttenuationContext{alpha, vis, conic, dx, dy, maximum_alpha}
+        EvaluateLightAttenuationContext<ScalarType, Vec3Type>{
+            alpha, vis, conic, dx, dy, maximum_alpha
+        }
     };
 }
 
+template <typename ScalarType, typename Vec2Type, typename Vec3Type>
 inline TREND_HOST_DEVICE auto evaluate_light_attenuation_backward(
     // context from forward pass
-    EvaluateLightAttenuationContext ctx,
+    EvaluateLightAttenuationContext<ScalarType, Vec3Type> ctx,
     // gradient of outputs
-    const float v_alpha,
+    const ScalarType v_alpha,
     // gradients of inputs
-    float &v_opacity,
-    fvec2 &v_mean,
-    fvec3 &v_conic
+    ScalarType &v_opacity,
+    Vec2Type &v_mean,
+    Vec3Type &v_conic
 ) -> void {
     if (ctx.alpha >= ctx.maximum_alpha) {
         return; // clip happens so no gradient
@@ -59,24 +70,26 @@ inline TREND_HOST_DEVICE auto evaluate_light_attenuation_backward(
 
     auto const v_sigma = -ctx.alpha * v_alpha;
     v_opacity += ctx.vis * v_alpha;
-    v_mean += v_sigma * fvec2{
+    v_mean += v_sigma * Vec2Type{
                             ctx.conic[0] * ctx.dx + ctx.conic[1] * ctx.dy,
                             ctx.conic[1] * ctx.dx + ctx.conic[2] * ctx.dy
                         };
-    v_conic += v_sigma *
-               fvec3{0.5f * ctx.dx * ctx.dx, ctx.dx * ctx.dy, 0.5f * ctx.dy * ctx.dy};
+    v_conic +=
+        v_sigma *
+        Vec3Type{0.5f * ctx.dx * ctx.dx, ctx.dx * ctx.dy, 0.5f * ctx.dy * ctx.dy};
 }
 
 #endif
 
-template <size_t FEATURE_DIM>
+template <size_t FEATURE_DIM, typename ScalarType, typename Vec2Type, typename Vec3Type>
 void image_gaussian_rasterize_kernel_forward(
     // Primitives
     const size_t n_primitives,
-    const float *__restrict__ opacity_ptr,       // [n_primitives]
-    fvec2 *__restrict__ mean_ptr,                // [n_primitives, 2]
-    fvec3 *__restrict__ conic_ptr,               // [n_primitives, 3]
-    fvec<FEATURE_DIM> *__restrict__ feature_ptr, // [n_primitives, FEATURE_DIM]
+    const ScalarType *__restrict__ opacity_ptr, // [n_primitives, 2]
+    const Vec2Type *__restrict__ mean_ptr,      // [n_primitives, 2, 2]
+    const Vec3Type *__restrict__ conic_ptr,     // [n_primitives, 3, 2]
+    const vec<ScalarType, FEATURE_DIM>
+        *__restrict__ feature_ptr, // [n_primitives, FEATURE_DIM, 2]
 
     // Images
     const size_t n_images,
@@ -92,9 +105,11 @@ void image_gaussian_rasterize_kernel_forward(
     // Outputs
     int32_t
         *__restrict__ render_last_index_ptr, // [n_images, image_height, image_width, 1]
-    float *__restrict__ render_alpha_ptr,    // [n_images, image_height, image_width, 1]
-    fvec<FEATURE_DIM> *__restrict__ render_feature_ptr // [n_images, image_height,
-                                                       // image_width, FEATURE_DIM]
+    ScalarType
+        *__restrict__ render_alpha_ptr, // [n_images, image_height, image_width, 1, 2]
+    vec<ScalarType, FEATURE_DIM>
+        *__restrict__ render_feature_ptr // [n_images, image_height,
+                                         // image_width, FEATURE_DIM, 2]
 );
 
 template <size_t FEATURE_DIM>

--- a/bindings/cugsplat/cuda/csrc/RasterizeToPixels3DGSFwdCUDA.cu
+++ b/bindings/cugsplat/cuda/csrc/RasterizeToPixels3DGSFwdCUDA.cu
@@ -2,6 +2,7 @@
 #include <cstdint>
 
 #include "RasterizeToPixels3DGS.h"
+#include "tinyrend/common/scalar_grad.h"
 #include "tinyrend/common/vec.h"
 #include "tinyrend/rasterization/base.cuh"
 #include "tinyrend/util/warp.cuh"
@@ -12,31 +13,35 @@ using namespace tinyrend;
 
 namespace cg = cooperative_groups;
 
-template <size_t FEATURE_DIM>
-struct ImageGaussianRasterizeKernelForwardOperator
+template <size_t FEATURE_DIM, typename ScalarType, typename Vec2Type, typename Vec3Type>
+struct ImageGaussianRasterizeKernelJvpOperator
     : tinyrend::rasterization::BaseRasterizeKernelOperator<
-          ImageGaussianRasterizeKernelForwardOperator<FEATURE_DIM>> {
+          ImageGaussianRasterizeKernelJvpOperator<
+              FEATURE_DIM,
+              ScalarType,
+              Vec2Type,
+              Vec3Type>> {
 
-    using FeatureType = fvec<FEATURE_DIM>;
-
+    using FeatureType = vec<ScalarType, FEATURE_DIM>;
     // Inputs
-    const float *__restrict__ opacity_ptr;       // [N, 1]
-    const fvec2 *__restrict__ mean_ptr;          // [N, 2]
-    const fvec3 *__restrict__ conic_ptr;         // [N, 3]
+    const ScalarType *__restrict__ opacity_ptr;  // [N, 1]
+    const Vec2Type *__restrict__ mean_ptr;       // [N, 2]
+    const Vec3Type *__restrict__ conic_ptr;      // [N, 3]
     const FeatureType *__restrict__ feature_ptr; // [N, FEATURE_DIM] (e.g., 3 for RGB or
                                                  // 256 for neural features)
 
     // Outputs
     int32_t
         *__restrict__ render_last_index_ptr; // [n_images, image_height, image_width, 1]
-    float *__restrict__ render_alpha_ptr;    // [n_images, image_height, image_width, 1]
+    ScalarType
+        *__restrict__ render_alpha_ptr; // [n_images, image_height, image_width, 1]
     FeatureType *__restrict__ render_feature_ptr; // [n_images, image_height,
                                                   // image_width, FEATURE_DIM]
 
     // Internal variables
     FeatureType _expected_feature =
-        FeatureType::zero();  // buffer for feature accumulation
-    float _T = 1.0f;          // current transmittance
+        FeatureType::zero();          // buffer for feature accumulation
+    ScalarType _T = ScalarType(1.0f); // current transmittance
     int32_t _last_index = -1; // the index of intersections ([n_isects]) for the last
                               // one being rasterized. -1 means no intersection.
 
@@ -48,18 +53,19 @@ struct ImageGaussianRasterizeKernelForwardOperator
 
     static inline __host__ auto sm_size_per_primitive_impl() -> uint32_t {
         // cache the opacity, mean, conic, and primitive_id
-        return sizeof(float) + sizeof(fvec2) + sizeof(fvec3) + sizeof(uint32_t);
+        return sizeof(ScalarType) + sizeof(Vec2Type) + sizeof(Vec3Type) +
+               sizeof(uint32_t);
     }
 
     inline __device__ auto initialize_impl() -> bool { return true; }
 
     inline __device__ auto primitive_preprocess_impl(uint32_t primitive_id) -> void {
         // cache data to shared memory
-        auto const sm_opacity_ptr = reinterpret_cast<float *>(this->sm_ptr);
+        auto const sm_opacity_ptr = reinterpret_cast<ScalarType *>(this->sm_ptr);
         auto const sm_mean_ptr =
-            reinterpret_cast<fvec2 *>(&sm_opacity_ptr[this->n_threads_per_block]);
+            reinterpret_cast<Vec2Type *>(&sm_opacity_ptr[this->n_threads_per_block]);
         auto const sm_conic_ptr =
-            reinterpret_cast<fvec3 *>(&sm_mean_ptr[this->n_threads_per_block]);
+            reinterpret_cast<Vec3Type *>(&sm_mean_ptr[this->n_threads_per_block]);
         auto const sm_primitive_id_ptr =
             reinterpret_cast<uint32_t *>(&sm_conic_ptr[this->n_threads_per_block]);
         sm_opacity_ptr[this->thread_rank] = this->opacity_ptr[primitive_id];
@@ -72,11 +78,11 @@ struct ImageGaussianRasterizeKernelForwardOperator
     inline __device__ auto
     rasterize_impl(uint32_t batch_start, uint32_t t, WarpT &warp) -> bool {
         // load data from shared memory
-        auto const sm_opacity_ptr = reinterpret_cast<float *>(this->sm_ptr);
+        auto const sm_opacity_ptr = reinterpret_cast<ScalarType *>(this->sm_ptr);
         auto const sm_mean_ptr =
-            reinterpret_cast<fvec2 *>(&sm_opacity_ptr[this->n_threads_per_block]);
+            reinterpret_cast<Vec2Type *>(&sm_opacity_ptr[this->n_threads_per_block]);
         auto const sm_conic_ptr =
-            reinterpret_cast<fvec3 *>(&sm_mean_ptr[this->n_threads_per_block]);
+            reinterpret_cast<Vec3Type *>(&sm_mean_ptr[this->n_threads_per_block]);
         auto const sm_primitive_id_ptr =
             reinterpret_cast<uint32_t *>(&sm_conic_ptr[this->n_threads_per_block]);
         auto const opacity = sm_opacity_ptr[t];
@@ -128,14 +134,15 @@ struct ImageGaussianRasterizeKernelForwardOperator
     }
 };
 
-template <size_t FEATURE_DIM>
+template <size_t FEATURE_DIM, typename ScalarType, typename Vec2Type, typename Vec3Type>
 void image_gaussian_rasterize_kernel_forward(
     // Primitives
     const size_t n_primitives,
-    const float *__restrict__ opacity_ptr,       // [n_primitives]
-    fvec2 *__restrict__ mean_ptr,                // [n_primitives, 2]
-    fvec3 *__restrict__ conic_ptr,               // [n_primitives, 3]
-    fvec<FEATURE_DIM> *__restrict__ feature_ptr, // [n_primitives, FEATURE_DIM]
+    const ScalarType *__restrict__ opacity_ptr, // [n_primitives]
+    const Vec2Type *__restrict__ mean_ptr,      // [n_primitives, 2]
+    const Vec3Type *__restrict__ conic_ptr,     // [n_primitives, 3]
+    const vec<ScalarType, FEATURE_DIM>
+        *__restrict__ feature_ptr, // [n_primitives, FEATURE_DIM]
 
     // Images
     const size_t n_images,
@@ -151,12 +158,15 @@ void image_gaussian_rasterize_kernel_forward(
     // Outputs
     int32_t
         *__restrict__ render_last_index_ptr, // [n_images, image_height, image_width, 1]
-    float *__restrict__ render_alpha_ptr,    // [n_images, image_height, image_width, 1]
-    fvec<FEATURE_DIM> *__restrict__ render_feature_ptr // [n_images, image_height,
-                                                       // image_width, FEATURE_DIM]
+    ScalarType
+        *__restrict__ render_alpha_ptr, // [n_images, image_height, image_width, 1]
+    vec<ScalarType, FEATURE_DIM>
+        *__restrict__ render_feature_ptr // [n_images, image_height,
+                                         // image_width, FEATURE_DIM]
 
 ) {
-    ImageGaussianRasterizeKernelForwardOperator<FEATURE_DIM> op{};
+    ImageGaussianRasterizeKernelJvpOperator<FEATURE_DIM, ScalarType, Vec2Type, Vec3Type>
+        op{};
     op.opacity_ptr = opacity_ptr;
     op.mean_ptr = mean_ptr;
     op.conic_ptr = conic_ptr;
@@ -193,13 +203,14 @@ void image_gaussian_rasterize_kernel_forward(
 // Explicit Instantiation: this should match how it is being called in .cpp
 // file.
 // TODO: this is slow to compile, can we do something about it?
-#define __INS__(DIM)                                                                   \
-    template void image_gaussian_rasterize_kernel_forward<DIM>(                        \
+#define __INS__(DIM, ScalarType, Vec2Type, Vec3Type)                                   \
+    template void                                                                      \
+    image_gaussian_rasterize_kernel_forward<DIM, ScalarType, Vec2Type, Vec3Type>(      \
         const size_t n_primitives,                                                     \
-        const float *__restrict__ opacity_ptr,                                         \
-        fvec2 *__restrict__ mean_ptr,                                                  \
-        fvec3 *__restrict__ conic_ptr,                                                 \
-        fvec<DIM> *__restrict__ feature_ptr,                                           \
+        const ScalarType *__restrict__ opacity_ptr,                                    \
+        const Vec2Type *__restrict__ mean_ptr,                                         \
+        const Vec3Type *__restrict__ conic_ptr,                                        \
+        const vec<ScalarType, DIM> *__restrict__ feature_ptr,                          \
         const size_t n_images,                                                         \
         const size_t image_height,                                                     \
         const size_t image_width,                                                      \
@@ -208,11 +219,19 @@ void image_gaussian_rasterize_kernel_forward(
         const uint32_t *__restrict__ isect_primitive_ids,                              \
         const uint32_t *__restrict__ isect_prefix_sum_per_tile,                        \
         int32_t *__restrict__ render_last_index_ptr,                                   \
-        float *__restrict__ render_alpha_ptr,                                          \
-        fvec<DIM> *__restrict__ render_feature_ptr                                     \
+        ScalarType *__restrict__ render_alpha_ptr,                                     \
+        vec<ScalarType, DIM> *__restrict__ render_feature_ptr                          \
     );
 
-__INS__(3)
+// Forward without grads
+__INS__(3, float, fvec2, fvec3)
+
+// JVP: Forward with grads
+using JVP_ScalarType = scalar_grad<float>;
+using JVP_Vec2Type = vec<scalar_grad<float>, 2>;
+using JVP_Vec3Type = vec<scalar_grad<float>, 3>;
+__INS__(3, JVP_ScalarType, JVP_Vec2Type, JVP_Vec3Type)
+
 #undef __INS__
 
 } // namespace cugsplat

--- a/bindings/cugsplat/cuda/csrc/ext.cpp
+++ b/bindings/cugsplat/cuda/csrc/ext.cpp
@@ -6,6 +6,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def(
         "image_gaussian_rasterize_forward", &cugsplat::image_gaussian_rasterize_forward
     );
+    m.def("image_gaussian_rasterize_jvp", &cugsplat::image_gaussian_rasterize_jvp);
     m.def(
         "image_gaussian_rasterize_backward",
         &cugsplat::image_gaussian_rasterize_backward

--- a/bindings/cugsplat/tests/test_rasterization.py
+++ b/bindings/cugsplat/tests/test_rasterization.py
@@ -17,8 +17,7 @@ import tqdm
 device = torch.device("cuda")
 
 
-@pytest.fixture
-def test_data():
+def create_test_data():
     torch.manual_seed(42)
 
     from gsplat._helper import load_test_data
@@ -46,6 +45,11 @@ def test_data():
         "width": width,
         "height": height,
     }
+    
+
+@pytest.fixture
+def test_data():
+    return create_test_data()
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
@@ -53,7 +57,8 @@ def test_data():
 # @pytest.mark.parametrize("batch_dims", [(), (2,), (1, 2)])
 @pytest.mark.parametrize("channels", [3])
 @pytest.mark.parametrize("batch_dims", [()])
-def test_rasterize_to_pixels(test_data, channels: int, batch_dims: Tuple[int, ...]):
+@pytest.mark.parametrize("benchmark", [False])
+def test_rasterize_to_pixels(test_data, channels: int, batch_dims: Tuple[int, ...], benchmark: bool):
     from gsplat.cuda._wrapper import (
         fully_fused_projection,
         isect_offset_encode,
@@ -126,22 +131,48 @@ def test_rasterize_to_pixels(test_data, channels: int, batch_dims: Tuple[int, ..
     isect_prefix_sum[:-1] = isect_offsets[1:]
     isect_prefix_sum[-1] = flatten_ids.numel()
 
-    render_colors_, render_alphas_, render_last_ids_ = _C.image_gaussian_rasterize_forward(
-        opacities.reshape(-1).contiguous(),
-        means2d.reshape(-1, 2).contiguous(),
-        conics.reshape(-1, 3).contiguous(),
-        colors.reshape(-1, channels).contiguous(),
-        I,
-        width,
-        height,
-        tile_size, # tile_width
-        tile_size, # tile_height
-        flatten_ids.reshape(-1).to(torch.uint32).contiguous(),   
-        isect_prefix_sum.reshape(-1).to(torch.uint32).contiguous(),
-    )
+    for _ in tqdm.trange(10000 if benchmark else 1, disable=not benchmark, desc="Forward"):
+        render_colors_, render_alphas_, render_last_ids_ = _C.image_gaussian_rasterize_forward(
+            opacities.reshape(-1).contiguous(),
+            means2d.reshape(-1, 2).contiguous(),
+            conics.reshape(-1, 3).contiguous(),
+            colors.reshape(-1, channels).contiguous(),
+            I,
+            width,
+            height,
+            tile_size, # tile_width
+            tile_size, # tile_height
+            flatten_ids.reshape(-1).to(torch.uint32).contiguous(),   
+            isect_prefix_sum.reshape(-1).to(torch.uint32).contiguous(),
+        )
 
     torch.testing.assert_close(render_colors, render_colors_)
     torch.testing.assert_close(render_alphas, render_alphas_)
+
+    # jvp
+    opacities_with_grad = torch.stack([opacities, torch.rand_like(opacities)], dim=-1)
+    means2d_with_grad = torch.stack([means2d, torch.rand_like(means2d)], dim=-1)
+    conics_with_grad = torch.stack([conics, torch.rand_like(conics)], dim=-1)
+    colors_with_grad = torch.stack([colors, torch.rand_like(colors)], dim=-1)
+    for _ in tqdm.trange(10000 if benchmark else 1, disable=not benchmark, desc="JVP"):
+        render_colors_, render_alphas_, render_last_ids_ = _C.image_gaussian_rasterize_jvp(
+            opacities_with_grad.reshape(-1, 2).contiguous(),
+            means2d_with_grad.reshape(-1, 2, 2).contiguous(),
+            conics_with_grad.reshape(-1, 3, 2).contiguous(),
+            colors_with_grad.reshape(-1, channels, 2).contiguous(),
+            I,
+            width,
+            height,
+            tile_size, # tile_width
+            tile_size, # tile_height
+            flatten_ids.reshape(-1).to(torch.uint32).contiguous(),   
+            isect_prefix_sum.reshape(-1).to(torch.uint32).contiguous(),
+        )
+    # render_colors_ shape: [n_images, image_height, image_width, channels, 2]
+    # render_alphas_ shape: [n_images, image_height, image_width, 1, 2]
+
+    torch.testing.assert_close(render_colors, render_colors_[..., 0])
+    torch.testing.assert_close(render_alphas, render_alphas_[..., 0])
 
     # # backward
     # v_render_colors = torch.randn_like(render_colors)
@@ -185,3 +216,6 @@ def test_rasterize_to_pixels(test_data, channels: int, batch_dims: Tuple[int, ..
     # torch.testing.assert_close(v_backgrounds, _v_backgrounds, rtol=1e-3, atol=1e-3)
 
 
+if __name__ == "__main__":
+    data = create_test_data()
+    test_rasterize_to_pixels(test_data=data, channels=3, batch_dims=(), benchmark=True)

--- a/include/tinyrend/common/math.h
+++ b/include/tinyrend/common/math.h
@@ -8,11 +8,14 @@
 namespace tinyrend {
 
 template <typename T> inline TREND_HOST_DEVICE T rsqrt(const T x) {
-#ifdef __CUDACC__
-    return ::rsqrt(x); // use CUDA's fast rsqrt()
-#else
-    return 1.0 / std::sqrt(x); // use standard sqrt on CPU
-#endif
+    // #ifdef __CUDACC__
+    //     return ::rsqrt(x); // use CUDA's fast rsqrt()
+    // #else
+    //     return 1.0 / sqrt(x); // use standard sqrt on CPU
+    // #endif
+
+    // Always use standard sqrt as T might be a scalar_grad
+    return 1.0 / sqrt(x); // use standard sqrt on CPU
 }
 
 } // namespace tinyrend

--- a/include/tinyrend/common/scalar_grad.h
+++ b/include/tinyrend/common/scalar_grad.h
@@ -1,0 +1,293 @@
+#pragma once
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <sstream>
+#include <string>
+
+#include "tinyrend/common/macros.h"
+#include "tinyrend/common/math.h"
+
+namespace tinyrend {
+
+template <typename T> struct alignas(T) scalar_grad {
+    T scalar;
+    T grad;
+
+    // Default constructor
+    constexpr scalar_grad() = default;
+
+    // Constructor from scalar and grad: TODO: should we set grad to 0 if not provided?
+    template <typename Type, typename = std::enable_if_t<std::is_arithmetic_v<Type>>>
+    TREND_HOST_DEVICE scalar_grad(Type scalar, Type grad = T(0))
+        : scalar(static_cast<T>(scalar)), grad(static_cast<T>(grad)) {}
+
+    // Unary minus operator
+    TREND_HOST_DEVICE scalar_grad operator-() const {
+        return scalar_grad(-scalar, -grad);
+    }
+
+    // Vector-Vector operations
+    TREND_HOST_DEVICE scalar_grad operator+(const scalar_grad &other) const {
+        return scalar_grad(scalar + other.scalar, grad + other.grad);
+    }
+
+    TREND_HOST_DEVICE scalar_grad operator-(const scalar_grad &other) const {
+        return scalar_grad(scalar - other.scalar, grad - other.grad);
+    }
+
+    TREND_HOST_DEVICE scalar_grad operator*(const scalar_grad &other) const {
+        return scalar_grad(
+            scalar * other.scalar, grad * other.scalar + scalar * other.grad
+        );
+    }
+
+    TREND_HOST_DEVICE scalar_grad operator/(const scalar_grad &other) const {
+        return scalar_grad(
+            scalar / other.scalar,
+            (grad * other.scalar - scalar * other.grad) / (other.scalar * other.scalar)
+        );
+    }
+
+    // Vector-Scalar operations
+    template <typename Type, typename = std::enable_if_t<std::is_arithmetic_v<Type>>>
+    TREND_HOST_DEVICE scalar_grad operator+(Type other) const {
+        T other_scalar = static_cast<T>(other);
+        return scalar_grad(scalar + other_scalar, grad);
+    }
+
+    template <typename Type, typename = std::enable_if_t<std::is_arithmetic_v<Type>>>
+    TREND_HOST_DEVICE scalar_grad operator-(Type other) const {
+        T other_scalar = static_cast<T>(other);
+        return scalar_grad(scalar - other_scalar, grad);
+    }
+
+    template <typename Type, typename = std::enable_if_t<std::is_arithmetic_v<Type>>>
+    TREND_HOST_DEVICE scalar_grad operator*(Type other) const {
+        T other_scalar = static_cast<T>(other);
+        return scalar_grad(scalar * other_scalar, grad * other_scalar);
+    }
+
+    template <typename Type, typename = std::enable_if_t<std::is_arithmetic_v<Type>>>
+    TREND_HOST_DEVICE scalar_grad operator/(Type other) const {
+        T other_scalar = static_cast<T>(other);
+        return scalar_grad(scalar / other_scalar, grad / other_scalar);
+    }
+
+    // Scalar-Vector operations (friend functions)
+    template <typename Type, typename = std::enable_if_t<std::is_arithmetic_v<Type>>>
+    TREND_HOST_DEVICE friend scalar_grad operator+(Type scalar, const scalar_grad &v) {
+        T scalar_scalar = static_cast<T>(scalar);
+        return scalar_grad(scalar_scalar + v.scalar, v.grad);
+    }
+
+    template <typename Type, typename = std::enable_if_t<std::is_arithmetic_v<Type>>>
+    TREND_HOST_DEVICE friend scalar_grad operator-(Type scalar, const scalar_grad &v) {
+        T scalar_scalar = static_cast<T>(scalar);
+        return scalar_grad(scalar_scalar - v.scalar, -v.grad);
+    }
+
+    template <typename Type, typename = std::enable_if_t<std::is_arithmetic_v<Type>>>
+    TREND_HOST_DEVICE friend scalar_grad operator*(Type scalar, const scalar_grad &v) {
+        T scalar_scalar = static_cast<T>(scalar);
+        return scalar_grad(scalar_scalar * v.scalar, scalar_scalar * v.grad);
+    }
+
+    template <typename Type, typename = std::enable_if_t<std::is_arithmetic_v<Type>>>
+    TREND_HOST_DEVICE friend scalar_grad operator/(Type scalar, const scalar_grad &v) {
+        T scalar_scalar = static_cast<T>(scalar);
+        return scalar_grad(
+            scalar_scalar / v.scalar, -scalar_scalar * v.grad / (v.scalar * v.scalar)
+        );
+    }
+
+    // Compound assignment operators
+    TREND_HOST_DEVICE scalar_grad &operator+=(const scalar_grad &other) {
+        scalar += other.scalar;
+        grad += other.grad;
+        return *this;
+    }
+
+    TREND_HOST_DEVICE scalar_grad &operator-=(const scalar_grad &other) {
+        scalar -= other.scalar;
+        grad -= other.grad;
+        return *this;
+    }
+
+    TREND_HOST_DEVICE scalar_grad &operator*=(const scalar_grad &other) {
+        scalar *= other.scalar;
+        grad = grad * other.scalar + scalar * other.grad;
+        return *this;
+    }
+
+    TREND_HOST_DEVICE scalar_grad &operator/=(const scalar_grad &other) {
+        scalar /= other.scalar;
+        grad =
+            (grad * other.scalar - scalar * other.grad) / (other.scalar * other.scalar);
+        return *this;
+    }
+
+    template <typename Type, typename = std::enable_if_t<std::is_arithmetic_v<Type>>>
+    TREND_HOST_DEVICE scalar_grad &operator+=(Type other) {
+        T other_scalar = static_cast<T>(other);
+        scalar += other_scalar;
+        return *this;
+    }
+
+    template <typename Type, typename = std::enable_if_t<std::is_arithmetic_v<Type>>>
+    TREND_HOST_DEVICE scalar_grad &operator-=(Type other) {
+        T other_scalar = static_cast<T>(other);
+        scalar -= other_scalar;
+        return *this;
+    }
+
+    template <typename Type, typename = std::enable_if_t<std::is_arithmetic_v<Type>>>
+    TREND_HOST_DEVICE scalar_grad &operator*=(Type other) {
+        T other_scalar = static_cast<T>(other);
+        scalar *= other_scalar;
+        grad *= other_scalar;
+        return *this;
+    }
+
+    template <typename Type, typename = std::enable_if_t<std::is_arithmetic_v<Type>>>
+    TREND_HOST_DEVICE scalar_grad &operator/=(Type other) {
+        T other_scalar = static_cast<T>(other);
+        scalar /= other_scalar;
+        grad /= other_scalar;
+        return *this;
+    }
+
+    // Vector-Vector comparison operators
+    TREND_HOST_DEVICE bool operator==(const scalar_grad &other) const {
+        return scalar == other.scalar;
+    }
+
+    TREND_HOST_DEVICE bool operator!=(const scalar_grad &other) const {
+        return !(*this == other);
+    }
+
+    TREND_HOST_DEVICE bool operator<(const scalar_grad &other) const {
+        return scalar < other.scalar;
+    }
+
+    TREND_HOST_DEVICE bool operator>(const scalar_grad &other) const {
+        return scalar > other.scalar;
+    }
+
+    TREND_HOST_DEVICE bool operator<=(const scalar_grad &other) const {
+        return scalar <= other.scalar;
+    }
+
+    TREND_HOST_DEVICE bool operator>=(const scalar_grad &other) const {
+        return scalar >= other.scalar;
+    }
+
+    // Vector-Scalar comparison operators
+    template <typename Type, typename = std::enable_if_t<std::is_arithmetic_v<Type>>>
+    TREND_HOST_DEVICE bool operator==(Type other) const {
+        return scalar == static_cast<T>(other);
+    }
+
+    template <typename Type, typename = std::enable_if_t<std::is_arithmetic_v<Type>>>
+    TREND_HOST_DEVICE bool operator!=(Type other) const {
+        return !(*this == other);
+    }
+
+    template <typename Type, typename = std::enable_if_t<std::is_arithmetic_v<Type>>>
+    TREND_HOST_DEVICE bool operator<(Type other) const {
+        return scalar < static_cast<T>(other);
+    }
+
+    template <typename Type, typename = std::enable_if_t<std::is_arithmetic_v<Type>>>
+    TREND_HOST_DEVICE bool operator>(Type other) const {
+        return scalar > static_cast<T>(other);
+    }
+
+    template <typename Type, typename = std::enable_if_t<std::is_arithmetic_v<Type>>>
+    TREND_HOST_DEVICE bool operator<=(Type other) const {
+        return scalar <= static_cast<T>(other);
+    }
+
+    template <typename Type, typename = std::enable_if_t<std::is_arithmetic_v<Type>>>
+    TREND_HOST_DEVICE bool operator>=(Type other) const {
+        return scalar >= static_cast<T>(other);
+    }
+
+    // to string
+    std::string to_string() const {
+        return "scalar_grad(" + std::to_string(scalar) + ", " + std::to_string(grad) +
+               ")";
+    }
+};
+
+// overload operators
+template <typename T>
+std::ostream &operator<<(std::ostream &os, const scalar_grad<T> &x) {
+    os << x.to_string();
+    return os;
+}
+
+template <typename T> TREND_HOST_DEVICE scalar_grad<T> abs(const scalar_grad<T> &a) {
+    T data = std::abs(a.scalar);
+    T grad = a.grad * (a.scalar >= 0 ? 1 : -1);
+    return scalar_grad<T>(data, grad);
+}
+
+template <typename T> TREND_HOST_DEVICE scalar_grad<T> sqrt(const scalar_grad<T> &a) {
+    T data = std::sqrt(a.scalar);
+    T grad = a.grad / (2.0f * data);
+    return scalar_grad<T>(data, grad);
+}
+
+template <typename T> TREND_HOST_DEVICE scalar_grad<T> exp(const scalar_grad<T> &a) {
+    T data = std::exp(a.scalar);
+    T grad = data * a.grad;
+    return scalar_grad<T>(data, grad);
+}
+
+template <typename T>
+TREND_HOST_DEVICE scalar_grad<T>
+fmax(const scalar_grad<T> &a, const scalar_grad<T> &b) {
+    T data = std::max(a.scalar, b.scalar);
+    T grad = (a.scalar >= b.scalar ? a.grad : b.grad);
+    return scalar_grad<T>(data, grad);
+}
+
+template <typename T>
+TREND_HOST_DEVICE scalar_grad<T> fmax(const scalar_grad<T> &a, const T &b) {
+    T data = std::max(a.scalar, b);
+    T grad = (a.scalar >= b ? a.grad : 0);
+    return scalar_grad<T>(data, grad);
+}
+
+template <typename T>
+TREND_HOST_DEVICE scalar_grad<T> fmax(const T &a, const scalar_grad<T> &b) {
+    T data = std::max(a, b.scalar);
+    T grad = (a >= b.scalar ? 0 : b.grad);
+    return scalar_grad<T>(data, grad);
+}
+
+template <typename T>
+TREND_HOST_DEVICE scalar_grad<T>
+fmin(const scalar_grad<T> &a, const scalar_grad<T> &b) {
+    T data = std::min(a.scalar, b.scalar);
+    T grad = (a.scalar <= b.scalar ? a.grad : b.grad);
+    return scalar_grad<T>(data, grad);
+}
+
+template <typename T>
+TREND_HOST_DEVICE scalar_grad<T> fmin(const scalar_grad<T> &a, const T &b) {
+    T data = std::min(a.scalar, b);
+    T grad = (a.scalar <= b ? a.grad : 0);
+    return scalar_grad<T>(data, grad);
+}
+
+template <typename T>
+TREND_HOST_DEVICE scalar_grad<T> fmin(const T &a, const scalar_grad<T> &b) {
+    T data = std::min(a, b.scalar);
+    T grad = (a <= b.scalar ? 0 : b.grad);
+    return scalar_grad<T>(data, grad);
+}
+
+} // namespace tinyrend

--- a/include/tinyrend/common/vec.h
+++ b/include/tinyrend/common/vec.h
@@ -267,7 +267,7 @@ template <typename T, size_t N> struct alignas(T) vec {
     is_close(const vec<T, N> &other, T atol = 1e-5f, T rtol = 1e-5f) const {
 #pragma unroll
         for (size_t i = 0; i < N; ++i) {
-            if (std::abs(data[i] - other[i]) > atol + rtol * std::abs(other[i])) {
+            if (abs(data[i] - other[i]) > atol + rtol * abs(other[i])) {
                 return false;
             }
         }
@@ -321,7 +321,7 @@ inline TREND_HOST_DEVICE vec<T, N> cross(const vec<T, N> &v1, const vec<T, N> &v
 }
 
 template <typename T, size_t N> inline TREND_HOST_DEVICE T length(const vec<T, N> &v) {
-    return std::sqrt(dot(v, v));
+    return sqrt(dot(v, v));
 }
 
 template <typename T, size_t N> inline TREND_HOST_DEVICE T length2(const vec<T, N> &v) {
@@ -331,10 +331,10 @@ template <typename T, size_t N> inline TREND_HOST_DEVICE T length2(const vec<T, 
 template <typename T, size_t N>
 inline TREND_HOST_DEVICE T safe_length(const vec<T, N> &v) {
     // Find the maximum absolute value
-    T max_abs = std::fabs(v[0]);
+    T max_abs = abs(v[0]);
 #pragma unroll
     for (size_t i = 1; i < N; ++i) {
-        max_abs = std::fmax(max_abs, std::fabs(v[i]));
+        max_abs = fmax(max_abs, abs(v[i]));
     }
 
     if (max_abs <= T(0))
@@ -349,7 +349,7 @@ inline TREND_HOST_DEVICE T safe_length(const vec<T, N> &v) {
         sum_squares += ratio * ratio;
     }
 
-    return max_abs * std::sqrt(sum_squares);
+    return max_abs * sqrt(sum_squares);
 }
 
 template <typename T, size_t N>

--- a/tests/common/vec_scalar_grad.cpp
+++ b/tests/common/vec_scalar_grad.cpp
@@ -1,0 +1,204 @@
+#include <cassert>
+#include <stdio.h>
+
+#include "../helpers.h"
+#include "tinyrend/common/scalar_grad.h"
+#include "tinyrend/common/vec.h"
+
+using namespace tinyrend;
+
+using fsg = scalar_grad<float>;
+using fsg_vec3 = vec<fsg, 3>;
+using fsg_vec2 = vec<fsg, 2>;
+
+template <typename T>
+TREND_HOST_DEVICE bool is_close(
+    const scalar_grad<T> &x, const scalar_grad<T> &other, T atol = 1e-5f, T rtol = 1e-5f
+) {
+    auto const is_scalar_close =
+        abs(x.scalar - other.scalar) <= atol + rtol * abs(other.scalar);
+    auto const is_grad_close =
+        abs(x.grad - other.grad) <= atol + rtol * abs(other.grad);
+    return is_scalar_close && is_grad_close;
+}
+
+template <typename T, size_t N>
+TREND_HOST_DEVICE bool is_close(
+    const vec<scalar_grad<T>, N> &x,
+    const vec<scalar_grad<T>, N> &y,
+    T atol = 1e-5f,
+    T rtol = 1e-5f
+) {
+#pragma unroll
+    for (size_t i = 0; i < N; ++i) {
+        if (!is_close(x[i], y[i], atol, rtol)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+int test() {
+    int fails = 0;
+
+    // Size of vec<scalar_grad<float>, N>
+    { fails += CHECK(sizeof(fsg_vec3) == 3 * 2 * sizeof(float), ""); }
+
+    // Cast float* to scalar_grad<float>* and cast scalar_grad<float>* to float*
+    {
+        float data[2] = {1.2f, 2.0f};
+        fsg v = *reinterpret_cast<fsg *>(data);
+        fails += CHECK(is_close(v, fsg(1.2f, 2.0f)), "");
+
+        float *data2 = reinterpret_cast<float *>(&v);
+        fails += CHECK(data2[0] == 1.2f, "");
+        fails += CHECK(data2[1] == 2.0f, "");
+    }
+
+    // Initialize from values and pointer
+    {
+        fsg data[3] = {fsg(1.2f, 1.0f), fsg(2.0f, 2.0f), fsg(3.0f, 3.0f)};
+        fsg_vec3 v1 = fsg_vec3::from_ptr(data);
+        fsg_vec3 v2 = fsg_vec3(fsg(1.2f, 1.0f), fsg(2.0f, 2.0f), fsg(3.0f, 3.0f));
+        fails += CHECK(v1 == v2, "");
+    }
+
+    // Zero initialization
+    {
+        fsg_vec3 v1 = fsg_vec3::zero();
+        fails += CHECK(is_close(v1, fsg_vec3(fsg(0), fsg(0), fsg(0))), "");
+    }
+
+    // Ones initialization
+    {
+        fsg_vec3 v1 = fsg_vec3::ones();
+        fails += CHECK(is_close(v1, fsg_vec3(fsg(1), fsg(1), fsg(1))), "");
+    }
+
+    // Sum
+    {
+        fsg_vec3 v1 = fsg_vec3(fsg(1.2f, 1.0f), fsg(2.0f, 2.0f), fsg(3.0f, 3.0f));
+        fails += CHECK(is_close(v1.sum(), fsg(6.2f, 6.0f)), "");
+    }
+
+    // Vector-Vector operations
+    {
+        fsg_vec3 v1 = fsg_vec3(fsg(1.2f, 1.0f), fsg(2.0f, 2.0f), fsg(3.0f, 3.0f));
+        fsg_vec3 v2 = fsg_vec3(fsg(4.0f, 4.0f), fsg(5.0f, 5.0f), fsg(6.0f, 6.0f));
+        fails += CHECK(
+            is_close(
+                v1 + v2, fsg_vec3(fsg(5.2f, 5.0f), fsg(7.0f, 7.0f), fsg(9.0f, 9.0f))
+            ),
+            ""
+        );
+        fails += CHECK(
+            is_close(
+                v1 - v2,
+                fsg_vec3(fsg(-2.8f, -3.0f), fsg(-3.0f, -3.0f), fsg(-3.0f, -3.0f))
+            ),
+            ""
+        );
+        fails += CHECK(
+            is_close(
+                v1 * v2, fsg_vec3(fsg(4.8f, 8.8f), fsg(10.0f, 20.0f), fsg(18.0f, 36.0f))
+            ),
+            ""
+        );
+        fails += CHECK(
+            is_close(
+                v1 / v2, fsg_vec3(fsg(0.3f, -0.05f), fsg(0.4f, 0.f), fsg(0.5f, 0.f))
+            ),
+            ""
+        );
+    }
+
+    // Scalar-Vector operations
+    {
+        fsg_vec3 v1 = fsg_vec3(fsg(1.2f, 1.0f), fsg(2.0f, 2.0f), fsg(3.0f, 3.0f));
+        fails += CHECK(
+            is_close(
+                1.0f + v1, fsg_vec3(fsg(2.2f, 1.0f), fsg(3.0f, 2.0f), fsg(4.0f, 3.0f))
+            ),
+            ""
+        );
+        fails += CHECK(
+            is_close(
+                1.0f - v1,
+                fsg_vec3(fsg(-0.2f, -1.0f), fsg(-1.0f, -2.0f), fsg(-2.0f, -3.0f))
+            ),
+            ""
+        );
+        fails += CHECK(
+            is_close(
+                1.0f * v1, fsg_vec3(fsg(1.2f, 1.0f), fsg(2.0f, 2.0f), fsg(3.0f, 3.0f))
+            ),
+            ""
+        );
+        fails += CHECK(
+            is_close(
+                1.44f / v1,
+                fsg_vec3(fsg(1.2f, -1.0f), fsg(0.72f, -0.72f), fsg(0.48f, -0.48f))
+            ),
+            ""
+        );
+    }
+
+    // Compound assignment operators
+    {
+        fsg_vec3 v1 = fsg_vec3(fsg(1.2f), fsg(2.0f), fsg(3.0f));
+        v1 += fsg_vec3(fsg(4.0f), fsg(5.0f), fsg(6.0f));
+        fails += CHECK(is_close(v1, fsg_vec3(fsg(5.2f), fsg(7.0f), fsg(9.0f))), "");
+        v1 -= fsg_vec3(fsg(4.0f), fsg(5.0f), fsg(6.0f));
+        fails += CHECK(is_close(v1, fsg_vec3(fsg(1.2f), fsg(2.0f), fsg(3.0f))), "");
+        v1 *= fsg_vec3(fsg(4.0f), fsg(5.0f), fsg(6.0f));
+        fails += CHECK(is_close(v1, fsg_vec3(fsg(4.8f), fsg(10.0f), fsg(18.0f))), "");
+        v1 /= fsg_vec3(fsg(4.0f), fsg(5.0f), fsg(6.0f));
+        fails += CHECK(is_close(v1, fsg_vec3(fsg(1.2f), fsg(2.0f), fsg(3.0f))), "");
+        v1 += fsg(1.0f);
+        fails += CHECK(is_close(v1, fsg_vec3(fsg(2.2f), fsg(3.0f), fsg(4.0f))), "");
+        v1 -= fsg(1.0f);
+        fails += CHECK(is_close(v1, fsg_vec3(fsg(1.2f), fsg(2.0f), fsg(3.0f))), "");
+        v1 *= fsg(2.0f);
+        fails += CHECK(is_close(v1, fsg_vec3(fsg(2.4f), fsg(4.0f), fsg(6.0f))), "");
+        v1 /= fsg(2.0f);
+    }
+
+    // Functions: length, safe_length
+    {
+        fsg_vec2 v1 = fsg_vec2(fsg(4.0f, 2.0f), fsg(3.0f, 1.0f));
+        fails += CHECK(is_close(length(v1), safe_length(v1)), "");
+
+        fsg_vec3 v2 = fsg_vec3(1.0f, 2.0f, 2.0f);
+        fails += CHECK(is_close(length(v2), safe_length(v2)), "");
+    }
+
+    // Functions: normalize, safe_normalize
+    {
+        fsg_vec2 v1 = fsg_vec2(fsg(4.0f, 2.0f), fsg(3.0f, 1.0f));
+        fails += CHECK(is_close(normalize(v1), safe_normalize(v1)), "");
+    }
+
+    // Functions: safe_normalize_vjp
+    {
+        fsg_vec2 v1 = fsg_vec2(fsg(4.0f, 2.0f), fsg(3.0f, 1.0f));
+        fsg_vec2 dl_dout = fsg_vec2(fsg(1.0f, 1.0f), fsg(2.0f, 2.0f));
+        fsg_vec2 dl_dv1_expected = fsg_vec2(fsg(-0.12f, -0.0736f), fsg(0.16f, 0.1248f));
+        fails += CHECK(is_close(safe_normalize_vjp(v1, dl_dout), dl_dv1_expected), "");
+    }
+
+    return fails;
+}
+
+int main() {
+    int fails = 0;
+
+    fails += test();
+
+    if (fails > 0) {
+        printf("[common/vec_scalar_grad.cpp] %d tests failed!\n", fails);
+    } else {
+        printf("[common/vec_scalar_grad.cpp] All tests passed!\n");
+    }
+
+    return fails;
+}


### PR DESCRIPTION
benchmarking (`python bindings/cugsplat/tests/test_rasterization.py`) gives me:
- forward pass: 2459.41it/s 
- jvp: 1416.63it/s